### PR TITLE
feat: add new payment request form events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stripe_presenter_plugin (1.3.1)
+    stripe_presenter_plugin (1.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/stripe_presenter_plugin/version.rb
+++ b/lib/stripe_presenter_plugin/version.rb
@@ -1,3 +1,3 @@
 module StripePresenterPlugin
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end

--- a/stripe_presenter_plugin.gemspec
+++ b/stripe_presenter_plugin.gemspec
@@ -5,11 +5,11 @@ require 'stripe_presenter_plugin/version'
 Gem::Specification.new do |spec|
   spec.name          = 'stripe_presenter_plugin'
   spec.version       = StripePresenterPlugin::VERSION
-  spec.authors       = ["Tyler Lemburg", "Derek Graham", "Russell Edens"]
-  spec.email         = ["derek@evvnt.com", "rx@evvnt.com"]
+  spec.authors       = ["Evvnt, Inc."]
+  spec.email         = ["dev@evvnt.com"]
 
-  spec.summary       = %q{A COPRL presenter plugin for stripe}
-  spec.homepage      = 'http://github.com/evvnt/stripe_presenters_plugin'
+  spec.summary       = %q{A COPRL presenter plugin for Stripe}
+  spec.homepage      = 'https://github.com/evvnt/stripe_presenters_plugin'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Add new payment request form events:

* `payment_started`: dispatched when a payment method is provided
* `payment_finished`: dispatched when the payment process completes
  (success or failure)
* `additional_action_failed`: dispatched when an additional Stripe payment
  action (e.g. external bank authentication) fails
* `additional_action_succeeded`: dispatched when an additional Stripe
  payment action (e.g. external bank authentication) succeeds